### PR TITLE
1.19-3.0.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,8 +5,8 @@ on: [ pull_request, workflow_dispatch ]
 env:
   MINECRAFT_VERSION: 1.19
   JAVA_VERSION: 17
-  VERSION: 1.19-3.0.0
-  RELEASE_NAME: Forgotten Graves 1.19-3.0.0
+  VERSION: 1.19-3.0.1
+  RELEASE_NAME: Forgotten Graves 1.19-3.0.1
   MODRINTH_TOKEN: ${{ secrets.PUBLISH_MODRINTH_TOKEN }}
   CURSEFORGE_TOKEN: ${{ secrets.PUBLISH_CURSEFORGE_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.19-3.0.1
+- Fix: CurseForge only offers 0.14.12 as the highest fabric loader version for 1.19. The mod now requires ">=0.14.0" instead of "0.14.13".
+
 ## 1.19-3.0.0
 
 - New: Updated to Minecraft v1.19.

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ minecraft_version=1.19
 yarn_mappings=1.19+build.4
 loader_version=0.14.13
 # Mod Properties
-mod_version=1.19-3.0.0
+mod_version=1.19-3.0.1
 maven_group=me.mgin
 archives_base_name=forgottengraves
 # Dependencies

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -32,7 +32,7 @@
   ],
 
   "depends": {
-    "fabricloader": "0.14.13",
+    "fabricloader": ">=0.14.0",
     "fabric": "0.58.0+1.19",
     "minecraft": "1.19",
     "cloth-config": "8.2.88"


### PR DESCRIPTION
CurseForge's highest fabric loader version, at least for 1.19, is 0.14.12. This causes an issue when trying to launch the game, as the mod requires "0.14.13". Thus, the requirement has been relaxed to ">=0.14.0".