### PR TITLE
Bump 1.19-3.0.1 -> 1.19-3.0.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,8 +5,8 @@ on: [ pull_request, workflow_dispatch ]
 env:
   MINECRAFT_VERSION: 1.19
   JAVA_VERSION: 17
-  VERSION: 1.19-3.0.1
-  RELEASE_NAME: Forgotten Graves 1.19-3.0.1
+  VERSION: 1.19-3.0.2
+  RELEASE_NAME: Forgotten Graves 1.19-3.0.2
   MODRINTH_TOKEN: ${{ secrets.PUBLISH_MODRINTH_TOKEN }}
   CURSEFORGE_TOKEN: ${{ secrets.PUBLISH_CURSEFORGE_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.19-3.0.2
+- Fix: Right-clicking on a waxed grave, without an item that can cause decay, should not cause "this grave has been waxed" error message.
+
 ## 1.19-3.0.1
 - Fix: CurseForge only offers 0.14.12 as the highest fabric loader version for 1.19. The mod now requires ">=0.14.0" instead of "0.14.13".
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ minecraft_version=1.19
 yarn_mappings=1.19+build.4
 loader_version=0.14.13
 # Mod Properties
-mod_version=1.19-3.0.1
+mod_version=1.19-3.0.2
 maven_group=me.mgin
 archives_base_name=forgottengraves
 # Dependencies

--- a/src/main/java/me/mgin/graves/event/server/useblock/item/DecayItem.java
+++ b/src/main/java/me/mgin/graves/event/server/useblock/item/DecayItem.java
@@ -38,7 +38,7 @@ public class DecayItem {
         boolean isMainHand = hand.equals(Hand.MAIN_HAND);
         boolean canDecay = entity.getNoDecay() == 0;
 
-        if (!canDecay) {
+        if (isDecayItem && canRetrieve && isMainHand && !canDecay) {
             player.sendMessage(
                 Text.translatable("event.use.itemDecay:error.noDecayEnabled").formatted(Formatting.RED)
             );

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -39,7 +39,7 @@
   },
 
   "recommends": {
-    "mod-menu": "*"
+    "modmenu": "*"
   },
 
   "suggests": {


### PR DESCRIPTION
Fixed: Right-clicking on a waxed grave, without an item that can cause decay, should not cause "this grave has been waxed" error message.