### PR TITLE
1.19-3.0.2 -> 1.19-3.0.3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,8 +5,8 @@ on: [ pull_request, workflow_dispatch ]
 env:
   MINECRAFT_VERSION: 1.19
   JAVA_VERSION: 17
-  VERSION: 1.19-3.0.2
-  RELEASE_NAME: Forgotten Graves 1.19-3.0.2
+  VERSION: 1.19-3.0.3
+  RELEASE_NAME: Forgotten Graves 1.19-3.0.3
   MODRINTH_TOKEN: ${{ secrets.PUBLISH_MODRINTH_TOKEN }}
   CURSEFORGE_TOKEN: ${{ secrets.PUBLISH_CURSEFORGE_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,4 @@
-## 1.19-3.0.2
-- Fix: Right-clicking on a waxed grave, without an item that can cause decay, should not cause "this grave has been waxed" error message.
-
-## 1.19-3.0.1
-- Fix: CurseForge only offers 0.14.12 as the highest fabric loader version for 1.19. The mod now requires ">=0.14.0" instead of "0.14.13".
-
-## 1.19-3.0.0
-
-- New: Updated to Minecraft v1.19.
-- New: Added commands to manipulate the client and server configurations.
-- New: Graves can now "sink" in different mediums (Air/Water/Lava). Read about that [here](https://github.com/ginsm/forgotten-graves/wiki/Graves#q-why-does-my-grave-sink-when-i-die-in-the-air-or-water).
-- Update: Some configuration option names have been reworked.
-- Update: Some configuration option values have been reworked.
-- Update: The wiki has been updated in its entirety.
-- Fix: Your inventory should no longer drop when retrieving a game with `dropType` set to `"DROP"`. Only the items in the grave will drop.
-- Fix: There was an edge case where armor could sometimes be duplicated. This has been fixed.
-- Fix: Graves should no longer lose GraveEntity data on the client; this was occurring when you didn't have permission to break the grave.
+## 1.19-3.0.3
+**Fixed**
+- Trinkets `drop-rule` compatibility: Graves only handle slots with their `drop_rule` set to `default` now.
+- Items with Curse of Vanishing and Curse of Binding will prioritize vanishing now.

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ minecraft_version=1.19
 yarn_mappings=1.19+build.4
 loader_version=0.14.13
 # Mod Properties
-mod_version=1.19-3.0.2
+mod_version=1.19-3.0.3
 maven_group=me.mgin
 archives_base_name=forgottengraves
 # Dependencies


### PR DESCRIPTION
## 1.19-3.0.3
**Fixed**
- Trinkets `drop-rule` compatibility: Graves only handle slots with their `drop_rule` set to `default` now.
- Items with Curse of Vanishing and Curse of Binding will prioritize vanishing now.