### PR TITLE
Fix `ru_ru.json`

### DIFF
--- a/src/main/resources/assets/forgottengraves/lang/ru_ru.json
+++ b/src/main/resources/assets/forgottengraves/lang/ru_ru.json
@@ -66,7 +66,7 @@
   "event.death:send-player-coordinates": "Могила создана в XYZ: %d %d %d.",
   "event.use.itemDecay:error.noDecayEnabled": "Эта могила уже является вощёной и защищена от разложения.",
 
-  "grave.coordinates": "XYZ: %d %d %d",,
+  "grave.coordinates": "XYZ: %d %d %d",
   "grave.died-on": "%s умер на %s",
 
   "forgottengraves.normal": "Забытые могилы",


### PR DESCRIPTION

An extra comma has been removed, which leads to the fact that all lines under it aren't translated
It's my fault from the previous PR. I've only just been able to see it in the game.
I have my custom resourcepack that overrides translations, but it doesn't help because the `ru_ru.json` is broken in the mod file
